### PR TITLE
5.x improvements/restore static property hoisting in withNavigation*

### DIFF
--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -32,12 +32,15 @@
   },
   "devDependencies": {
     "@react-navigation/native": "^5.9.8",
+    "@types/hoist-non-react-statics": "^3.3.1",
     "@types/react": "^16.9.53",
+    "hoist-non-react-statics": "^3.3.2",
     "react": "~16.13.1",
     "react-native-builder-bob": "^0.17.0",
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
+    "hoist-non-react-statics": "^3.3.2",
     "@react-navigation/native": "^5.0.5",
     "react": "*"
   },

--- a/packages/compat/src/withNavigation.tsx
+++ b/packages/compat/src/withNavigation.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 import type { NavigationProp, ParamListBase } from '@react-navigation/native';
 import useCompatNavigation from './useCompatNavigation';
 import type { CompatNavigationProp } from './types';
@@ -29,6 +30,8 @@ export default function withNavigation<
   WrappedComponent.displayName = `withNavigation(${
     Comp.displayName || Comp.name
   })`;
+
+  hoistNonReactStatics(WrappedComponent, Comp);
 
   return WrappedComponent;
 }

--- a/packages/compat/src/withNavigationFocus.tsx
+++ b/packages/compat/src/withNavigationFocus.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 import { useIsFocused } from '@react-navigation/native';
 
 type InjectedProps = {
@@ -26,6 +27,8 @@ export default function withNavigationFocus<
   WrappedComponent.displayName = `withNavigationFocus(${
     Comp.displayName || Comp.name
   })`;
+
+  hoistNonReactStatics(WrappedComponent, Comp);
 
   return WrappedComponent;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3929,6 +3929,14 @@
   resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.36.tgz#17ce0a235e9ffbcdcdf5095646b374c2bf615a4c"
   integrity sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ==
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
@@ -10202,7 +10210,7 @@ hoist-non-react-statics@^2.3.1:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==


### PR DESCRIPTION
## Motivation

- `withNavigation`
- `withNavigationFocus`

In 4.x, screen components that have been wrapped with these higher-order component methods were able to pass the `.navigationOptions` to the navigators: https://github.com/react-navigation/react-navigation/blob/46ecfc529023201f71b26eecea375ec4148be95b/packages/core/src/views/withNavigation.js#L38

In 5.x, that functionality is now gone: https://github.com/react-navigation/react-navigation/blob/6a64c0bae2772bf4e49d3f6d55a2ace9ff84dcee/packages/compat/src/withNavigation.tsx#L29-L33. That means if you use either of these HOCs, your screens would have lost the capability of modifying UI elements on the navigator using configuration like `.navigationOptions.headerLeft` because the 5.x HOCs have absorbed the `.navigationOptions` property — you would have to remove the replace the usage of those HOCs with the `useNavigation` / `useNavigationFocus` Hooks.

This issue is more difficult to migrate from in large codebases where you have, for example, hundreds of references to `withNavigation` and very little resources to migrate all of them at once.
