### PR TITLE
5.x improvements/restore navigation prop in withNavigationFocus

### DIFF
--- a/packages/compat/src/withNavigationFocus.tsx
+++ b/packages/compat/src/withNavigationFocus.tsx
@@ -1,27 +1,32 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { useIsFocused } from '@react-navigation/native';
+import { NavigationProp, ParamListBase, useIsFocused } from '@react-navigation/native';
+import type { CompatNavigationProp } from './types';
+import useCompatNavigation from './useCompatNavigation';
 
-type InjectedProps = {
+type InjectedProps<T extends NavigationProp<ParamListBase>> = {
   isFocused: boolean;
+  navigation: CompatNavigationProp<T>;
 };
 
 export default function withNavigationFocus<
-  P extends InjectedProps,
+  T extends NavigationProp<ParamListBase>,
+  P extends InjectedProps<T>,
   C extends React.ComponentType<P>
 >(Comp: C) {
   const WrappedComponent = ({
     onRef,
     ...rest
-  }: Exclude<P, InjectedProps> & {
+  }: Exclude<P, InjectedProps<T>> & {
     onRef?: C extends React.ComponentClass<any>
       ? React.Ref<InstanceType<C>>
       : never;
   }): React.ReactElement => {
     const isFocused = useIsFocused();
+    const navigation = useCompatNavigation<T>();
 
     // @ts-expect-error: type checking HOC is hard
-    return <Comp ref={onRef} isFocused={isFocused} {...rest} />;
+    return <Comp ref={onRef} isFocused={isFocused} navigation={navigation} {...rest} />;
   };
 
   WrappedComponent.displayName = `withNavigationFocus(${


### PR DESCRIPTION
## Motivation

In React Navigation v4, `props.navigation` used to exist via `withNavigationFocus()`, effectively making this HOC like `withNavigation()` + `props.isFocused`.

Now, with v5, the `navigation` prop is gone (unintentional?). We're restoring it for backwards capability with v4 usage.