### PR TITLE
5.x improvements/fix typescript props

### DIFF
--- a/packages/compat/src/types.tsx
+++ b/packages/compat/src/types.tsx
@@ -90,3 +90,18 @@ export type CompatRouteConfig<
         params?: ParamList[RouteName];
       });
 };
+
+export type NavigationParams = {
+  [key: string]: any;
+};
+
+export type NavigationInjectedProps<NP = NavigationParams> = {
+  navigation: CompatNavigationProp<
+    NavigationProp<{ [key: string]: NP } & ParamListBase>
+  >;
+};
+
+// eslint-disable-next-line prettier/prettier
+export type NavigationFocusInjectedProps<NP = NavigationParams> = NavigationInjectedProps<NP> & {
+  isFocused: boolean;
+};

--- a/packages/compat/src/withNavigationFocus.tsx
+++ b/packages/compat/src/withNavigationFocus.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { NavigationProp, ParamListBase, useIsFocused } from '@react-navigation/native';
-import type { CompatNavigationProp } from './types';
 import useCompatNavigation from './useCompatNavigation';
+import type { CompatNavigationProp } from './types';
 
 type InjectedProps<T extends NavigationProp<ParamListBase>> = {
   isFocused: boolean;


### PR DESCRIPTION
## Motivation

The current type generics setup makes it impossible for the component to pass the compiler. Giving better types will relinquish the type generics back to the consumer as was originally designed.
