### PR TITLE
5.x improvements/fix withNavigation HOC API alignment with legacy

### DIFF
--- a/packages/compat/src/withNavigation.tsx
+++ b/packages/compat/src/withNavigation.tsx
@@ -3,32 +3,50 @@ import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import type { NavigationProp } from '@react-navigation/native';
 import useCompatNavigation from './useCompatNavigation';
-import type { NavigationParams, NavigationInjectedProps } from './types';
+import type { NavigationParams } from './types';
 
 const withNavigation = <
-  C extends React.ComponentType<{}>,
+  C extends React.JSXElementConstructor<{}>,
   NP extends NavigationParams = NavigationParams
 >(
   Component: C
 ) => {
-  type WrappedP = React.ComponentProps<C> & NavigationInjectedProps<NP>;
+  type P = React.ComponentProps<C>;
+  type WrappedP = P & {
+    /**
+     * **NOTE**: Overriden by `.onRef` prop. Do not use `.ref`.
+     *           As per official React Navigation 5 API, use `.onRef` instead!
+     */
+    ref?: never;
+    /**
+     * Forwards ref to the wrapped component.
+     */
+    onRef?: C extends React.ComponentClass<{}>
+      ? React.LegacyRef<InstanceType<C>>
+      : C extends React.ForwardRefExoticComponent<P>
+        ? React.RefAttributes<React.ElementRef<C>>['ref']
+        : never;
+  };
 
-  const componentDisplayName = Component.displayName || Component.name;
+  const componentDisplayName = (Component as React.ComponentType<WrappedP>).displayName || Component.name;
   const WrappedComponent = Component as unknown as React.ComponentType<WrappedP>;
   const wrappedComponentDisplayName = `withNavigation(${componentDisplayName})`;
 
-  const NavigationComponent = React.forwardRef<C, WrappedP>((props, ref) => {
+  const NavigationComponent = (props: WrappedP) => {
     const navigation = useCompatNavigation<NavigationProp<NP>>();
 
     return (
     // @ts-expect-error: type checking HOC is hard
+    // if we hadn't override the built-in ref with our custom onRef (official API since v4!!!), this
+    // would've been fine without bypassing the type checking. unfortunately, v4 & v5/compat spec is
+    // like this, so, the bypass has to stay to ease the implementation...
       <WrappedComponent
         {...props}
-        ref={ref}
+        ref={props.onRef}
         navigation={navigation}
       />
     );
-  });
+  };
 
   hoistNonReactStatics(NavigationComponent, Component);
 

--- a/packages/compat/src/withNavigation.tsx
+++ b/packages/compat/src/withNavigation.tsx
@@ -52,7 +52,17 @@ const withNavigation = <
 
   NavigationComponent.displayName = wrappedComponentDisplayName;
 
-  return NavigationComponent;
+  // 1. Inject HOC-specific props.
+  // 2. Retain C-specific props.
+  // 3. Retain C-specific statics.
+  type NavigationComponentType =
+    C extends React.ForwardRefExoticComponent<{}>
+      ? React.ForwardRefExoticComponent<P & WrappedP> & Pick<C, keyof C> // React.forwardRef((props, ref) => <Element/>)
+      : C extends ((props: P) => React.ReactElement | undefined | null)
+        ? ((props: P & WrappedP) => ReturnType<C>) & Pick<C, keyof C> // (props) => <Element/>
+        : C & React.ComponentClass<P & WrappedP>; // class extends React.Component { render(): <Element/> }
+
+  return NavigationComponent as NavigationComponentType;
 };
 
 export default withNavigation;

--- a/packages/compat/src/withNavigationFocus.tsx
+++ b/packages/compat/src/withNavigationFocus.tsx
@@ -3,34 +3,52 @@ import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { NavigationProp, useIsFocused } from '@react-navigation/native';
 import useCompatNavigation from './useCompatNavigation';
-import type { NavigationParams, NavigationFocusInjectedProps } from './types';
+import type { NavigationParams } from './types';
 
 const withNavigation = <
-  C extends React.ComponentType<{}>,
+  C extends React.JSXElementConstructor<{}>,
   NP extends NavigationParams = NavigationParams
 >(
   Component: C
 ) => {
-  type WrappedP = React.ComponentProps<C> & NavigationFocusInjectedProps;
+  type P = React.ComponentProps<C>;
+  type WrappedP = P & {
+    /**
+     * **NOTE**: Overriden by `.onRef` prop. Do not use `.ref`.
+     *           As per official React Navigation 5 API, use `.onRef` instead!
+     */
+    ref?: never;
+    /**
+     * Forwards ref to the wrapped component.
+     */
+    onRef?: C extends React.ComponentClass<{}>
+      ? React.LegacyRef<InstanceType<C>>
+      : C extends React.ForwardRefExoticComponent<P>
+        ? React.RefAttributes<React.ElementRef<C>>['ref']
+        : never;
+  };
 
-  const componentDisplayName = Component.displayName || Component.name;
+  const componentDisplayName = (Component as React.ComponentType<WrappedP>).displayName || Component.name;
   const WrappedComponent = Component as unknown as React.ComponentType<WrappedP>;
   const wrappedComponentDisplayName = `withNavigation(${componentDisplayName})`;
 
-  const NavigationComponent = React.forwardRef<C, WrappedP>((props, ref) => {
+  const NavigationComponent = (props: WrappedP) => {
     const isFocused = useIsFocused();
     const navigation = useCompatNavigation<NavigationProp<NP>>();
 
     return (
     // @ts-expect-error: type checking HOC is hard
+    // if we hadn't override the built-in ref with our custom onRef (official API since v4!!!), this
+    // would've been fine without bypassing the type checking. unfortunately, v4 & v5/compat spec is
+    // like this, so, the bypass has to stay to ease the implementation...
       <WrappedComponent
         {...props}
-        ref={ref}
+        ref={props.onRef}
         isFocused={isFocused}
         navigation={navigation}
       />
     );
-  });
+  };
 
   hoistNonReactStatics(NavigationComponent, Component);
 

--- a/packages/compat/src/withNavigationFocus.tsx
+++ b/packages/compat/src/withNavigationFocus.tsx
@@ -54,7 +54,17 @@ const withNavigation = <
 
   NavigationComponent.displayName = wrappedComponentDisplayName;
 
-  return NavigationComponent;
+  // 1. Inject HOC-specific props.
+  // 2. Retain C-specific props.
+  // 3. Retain C-specific statics.
+  type NavigationComponentType =
+    C extends React.ForwardRefExoticComponent<{}>
+      ? React.ForwardRefExoticComponent<P & WrappedP> & Pick<C, keyof C> // React.forwardRef((props, ref) => <Element/>)
+      : C extends ((props: P) => React.ReactElement | undefined | null)
+        ? ((props: P & WrappedP) => ReturnType<C>) & Pick<C, keyof C> // (props) => <Element/>
+        : C & React.ComponentClass<P & WrappedP>; // class extends React.Component { render(): <Element/> }
+
+  return NavigationComponent as NavigationComponentType;
 };
 
 export default withNavigation;


### PR DESCRIPTION
## Motivation

Overlooked the importance of backwards compatibility from the original higher-order component (HOC) implementation in 4.x and 5.x/compat. In both cases, the HOCs don't expose a component's ref through the `ref` prop, but rather through the `onRef` prop.

- 4.x https://github.com/react-navigation/react-navigation/blob/4.x/packages/core/src/views/withNavigation.js#L29
- 5.x https://github.com/react-navigation/react-navigation/blob/5.x/packages/compat/src/withNavigation.tsx#L26

In the interest of retaining this backwards compatibility, the `onRef` prop is restored.

Additionally, the typings of the previous iterations (i.e.: props, statics) was far from the correct real-world representation when using the HOCs. Thus, some corrections are also introduced here.